### PR TITLE
Adding iResReqInfo parameter to retreive key details about the HTTP requests related to the responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ Simply take your encryption/decryption script (like Jojo's `crypt.py`), then rew
 |------------------------	|--------------------------------------------------------	|-------------------------------------------------------------------------------------------------------------------------------------------	|
 | Request Decryption     	| `decrypt_http_request(original_request, iRequestInfo)`    	| When the HTTP request is encrypted and you want Burpsuite to display it in the decrypted format.                                                                            	|
 | Request Re-encryption  	| `encrypt_http_request(original_request, iRequestInfo)`    	| When the decrypted HTTP request has been modified and you want to re-encrypt it so that it stays valid upon received by the server..      	|
-| Response Decryption    	| `decrypt_http_response(original_response, iResponseInfo)` 	| When the HTTP response is encrypted and you want Burpsuite to display it in the decrypted format.                                                                           	|
-| Response Re-encryption 	| `encrypt_http_response(original_response, iResponseInfo)` 	| When the decrypted HTTP response has been modified and you want to re-encrypt it so that it stays valid upon received by the application. 	|
+| Response Decryption    	| `decrypt_http_response(original_response, iResponseInfo, iResReqInfo)` 	| When the HTTP response is encrypted and you want Burpsuite to display it in the decrypted format.                                                                           	|
+| Response Re-encryption 	| `encrypt_http_response(original_response, iResponseInfo, iResReqInfo)` 	| When the decrypted HTTP response has been modified and you want to re-encrypt it so that it stays valid upon received by the application. 	|
 
-Every methods above receives two (2) parameters by design, `original_request` or `original_response` and `iRequestInfo` or `iResponseInfo`.
+Request process receives two (2) parameters by design, `original_request` and `iRequestInfo`, then Response process receives three (3) parameters by design, `original_response`, `iResponseInfo` and `iResReqInfo`.
 
 **original_request: string**
 
@@ -64,6 +64,10 @@ A parameter that contains Burp interface object used to retrieve key details abo
 **iResponseInfo: object** 
 
 A parameter that contains Burp interface object used to retrieve key details about the HTTP responses. See [iResponseInfo](https://portswigger.net/burp/extender/api/burp/iresponseinfo.html) for more information.
+
+**iResReqInfo: object** 
+
+A parameter that contains Burp interface object used to retrieve key details about the HTTP requests related to the responses. See [iResponseInfo](https://portswigger.net/burp/extender/api/burp/irequestinfo.html) for more information.
 
 ## Quick Start (Example)
 
@@ -127,9 +131,9 @@ In this **TODO:** section, you need to create a new Python class that implements
 
 After that, according to your needs, you might want to override any of the following available methods according to your needs: 
 - `decrypt_http_request(original_request, iRequestInfo)`
-- `decrypt_http_response(original_response, iResponseInfo)`
+- `decrypt_http_response(original_response, iResponseInfo, iResReqInfo)`
 - `encrypt_http_request(original_request, iRequestInfo)`
-- `encrypt_http_response(original_response, iResponseInfo)`
+- `encrypt_http_response(original_response, iResponseInfo, iResReqInfo)`
 
 In each of those methods, implement the encryption/decryption code that fits the cryptographic operation of your application, then return a `dictionary` object containing two attributes: **headers** and **body**. The returned values will be injected into Burpsuite when it displays the intercepted HTTP requests or responses.
 

--- a/samples/plainmaker-quickstart.py
+++ b/samples/plainmaker-quickstart.py
@@ -11,6 +11,7 @@ import hashlib
 from urlparse import urlparse
 from urllib import unquote, quote_plus
 from base64 import b64encode, b64decode
+from subprocess import Popen, PIPE
 
 # Jython imports
 from javax.crypto import Cipher
@@ -80,7 +81,7 @@ class IEncryptorDecryptor():
             "body": False
         }
 
-    def encrypt_http_response(self, original_response, iResponseInfo):
+    def encrypt_http_response(self, original_response, iResponseInfo, iResReqInfo):
         """
         Implement this method and perform a custom encryption algorithm and inject the encrypted values into HTTP response's statline, headers and body as the result.
 
@@ -102,7 +103,7 @@ class IEncryptorDecryptor():
             "body": False
         }
 
-    def decrypt_http_response(self, original_response, iResponseInfo):
+    def decrypt_http_response(self, original_response, iResponseInfo, iResReqInfo):
         """
         Implement this method and perform a custom decryption algorithm and inject the decrypted values into HTTP response's statline, headers and body as the result.
 
@@ -140,16 +141,16 @@ class IEncryptorDecryptor():
         burp_request = self.modify_burp_request(original_request, iRequestInfo, request_data)
         return burp_request
 
-    def handle_http_response(self, original_response, iResponseInfo, operation_mode):
+    def handle_http_response(self, original_response, iResponseInfo, iResReqInfo, operation_mode):
         """
         Return an injected/modified HTTP response in raw HTTP format
         """
 
         response_data = {}
         if (operation_mode == IEncryptorDecryptor.MODE_RESPONSE_ENCRYPT):
-            response_data = self.encrypt_http_response(original_response, iResponseInfo)
+            response_data = self.encrypt_http_response(original_response, iResponseInfo, iResReqInfo)
         elif (operation_mode == IEncryptorDecryptor.MODE_RESPONSE_DECRYPT):
-            response_data = self.decrypt_http_response(original_response, iResponseInfo)
+            response_data = self.decrypt_http_response(original_response, iResponseInfo, iResReqInfo)
         else:
             print("WARNING: unknown operation_mode: %s. Response will not be modified." % operation_mode)
 
@@ -178,7 +179,7 @@ class IEncryptorDecryptor():
 
         return custom_request
     
-    def modify_burp_response(self, original_response, iResponseInfo, response_data):
+    def modify_burp_response(self, original_response, iResponseInfo, iResReqInfo, response_data):
         orig_headers_array = iResponseInfo.getHeaders()
         orig_body = IEncryptorDecryptor.get_http_body(original_response, iResponseInfo)
 
@@ -217,9 +218,43 @@ class IEncryptorDecryptor():
         return req_uri
     
     @staticmethod
+    def get_request_params(iRequestInfo):
+        req_params = urlparse(str(iRequestInfo.getUrl())).query
+        return req_params
+    
+    @staticmethod
+    def get_response_request_method(iResReqInfo):
+        req_method = iResReqInfo.getMethod()
+        return req_method
+    
+    @staticmethod
+    def get_response_request_uri(iResReqInfo):
+        req_uri = urlparse(str(iResReqInfo.getUrl())).path
+        return req_uri
+    
+    @staticmethod
+    def get_response_request_params(iResReqInfo):
+        req_params = urlparse(str(iResReqInfo.getUrl())).query
+        return req_params
+    
+    @staticmethod
     def get_http_body(plain, iReqResInfo):
         req_body = plain[iReqResInfo.getBodyOffset():]
         return req_body
+
+    @staticmethod
+    def run_external_script(path_to_script, *args):
+        cmd = ["python3", path_to_script] + list(args)
+
+        proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
+        output = proc.stdout.read()
+        proc.stdout.close()
+
+        err = proc.stderr.read()
+        proc.stderr.close()
+        sys.stdout.write(err)
+
+        return output
 
 #####################################################################
 # TODO: Write and implement your own encryptor-decryptor class here.
@@ -241,7 +276,7 @@ class MyCustomEncryptorDecryptor(IEncryptorDecryptor, object):
             "body": "request=INJECTED_BY_PLAINMAKER_REQUEST_ENCRYPTION"
         }
     
-    def encrypt_http_response(self, original_response, iResponseInfo):
+    def encrypt_http_response(self, original_response, iResponseInfo, iResReqInfo):
         return {
             "headers": {
                 "date": "INJECTED_BY_PLAINMAKER_RESPONSE_ENCRYPTION",
@@ -264,7 +299,7 @@ class MyCustomEncryptorDecryptor(IEncryptorDecryptor, object):
             "body": "request=INJECTED_BY_PLAINMAKER_REQUEST_DECRYPTION"
         }
     
-    def decrypt_http_response(self, original_response, iResponseInfo):
+    def decrypt_http_response(self, original_response, iResponseInfo, iResReqInfo):
         return {
             "headers": {
                 "date": "INJECTED_BY_PLAINMAKER_RESPONSE_DECRYPTION",
@@ -311,7 +346,7 @@ class BurpExtender(IBurpExtender, IHttpListener, IProxyListener):
     #
 
     def processHttpMessage(self, toolFlag, messageIsRequest, messageInfo):
-        if toolFlag == IBurpExtenderCallbacks.TOOL_PROXY:
+        if toolFlag == IBurpExtenderCallbacks.TOOL_PROXY or toolFlag ==  IBurpExtenderCallbacks.TOOL_INTRUDER or toolFlag == IBurpExtenderCallbacks.TOOL_REPEATER:
             self.filter_message(self.HTTP_HANDLER, messageIsRequest, messageInfo)
 
     #
@@ -364,6 +399,7 @@ class BurpExtender(IBurpExtender, IHttpListener, IProxyListener):
         else:
             original_response = FloydsHelpers.jb2ps(messageInfo.getResponse())
             iResponseInfo = self._helpers.analyzeResponse(messageInfo.getResponse())
+            iResReqInfo = self._helpers.analyzeRequest(messageInfo)
             print("Original Response", original_response)
 
             # 3. Response Decryption Stage
@@ -374,7 +410,7 @@ class BurpExtender(IBurpExtender, IHttpListener, IProxyListener):
 
                 new_res = self.encdec.handle_http_response(
                     original_response, 
-                    iResponseInfo, 
+                    iResponseInfo, iResReqInfo, 
                     operation_mode=IEncryptorDecryptor.MODE_RESPONSE_DECRYPT
                 )
 
@@ -389,7 +425,7 @@ class BurpExtender(IBurpExtender, IHttpListener, IProxyListener):
                 print("4. Response Re-encryption Stage")
                 new_res = self.encdec.handle_http_response(
                     original_response, 
-                    iResponseInfo, 
+                    iResponseInfo, iResReqInfo, 
                     operation_mode=IEncryptorDecryptor.MODE_RESPONSE_ENCRYPT
                 )
                 new_res_bytes = FloydsHelpers.ps2jb(new_res)


### PR DESCRIPTION
In certain cases, we need information from which request this response was sent

so I added the iResReqInfo parameter to provide the Burp interface object to retrieve key details about the HTTP requests related to the responses

this can be used to retrieve some information such as the URI, HTTP method used and also the request body is the same as iRequestInfo

example
```
def decrypt_http_response(self, original_response, iResponseInfo, iResReqInfo):
        # retrieving details about the HTTP requests related to the responses
        print("Request Method:", self.get_response_request_method(iResReqInfo))
        print("Request URI:", self.get_response_request_uri(iResReqInfo))
        
        return {
            "headers": {},
            "body": False
        }
```